### PR TITLE
Comment out the tips

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,30 +7,41 @@ assignees: ''
 
 ---
 
-Please note although we can't commit to any timeline, priority will be given to those who are [Contributors](https://reactiveui.net/contribute/ ) to the project.
-
-If this is a question please ask on [StackOverflow](https://stackoverflow.com/).
+<!--
+Please note although we can't commit to any timeline, priority will be given to those who are [Contributors](https://reactiveui.net/contribute/) to the project. If this is a question please ask on [StackOverflow](https://stackoverflow.com/).
+-->
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
+
+
 
 **Steps To Reproduce**
+<!--
 Provide the steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+-->
+
+
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
+
+
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Environment(please complete the following information):**
- - OS: [e.g. iOS]
- - Version [e.g. 22]
- - Device: [e.g. iPhone6]
+
+
+**Environment**
+<!-- Please complete the following information. -->
+- OS:       <!-- [e.g. iOS] -->
+- Version   <!-- [e.g. 22] -->
+- Device:   <!-- [e.g. iPhone6] -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,21 +7,29 @@ assignees: ''
 
 ---
 
-Please note although we can't commit to any timeline, priority will be given to those who are [Contributors](https://reactiveui.net/contribute/ ) to the project.
-
-If this is a question please ask on [StackOverflow](https://stackoverflow.com/).
+<!--
+Please note although we can't commit to any timeline, priority will be given to those who are [Contributors](https://reactiveui.net/contribute/) to the project. If this is a question please ask on [StackOverflow](https://stackoverflow.com/).
+-->
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is.
+<!-- A clear and concise description of what the problem is. -->
+
+
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
+
+
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+
 
 **Describe suggestions on how to achieve the feature**
-A clear description to how to achieve the feature.
+<!-- A clear description to how to achieve the feature. -->
+
+
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
-**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
+**What kind of change does this PR introduce?**
+<!-- Bug fix, feature, docs update, ... -->
 
 
 
-**What is the current behavior? (You can also link to an open issue here)**
+**What is the current behavior?**
+<!-- You can also link to an open issue here. -->
 
 
 
-**What is the new behavior (if this is a feature change)?**
+**What is the new behavior?**
+<!-- If this is a feature change -->
 
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Updated issue/pr templates, commented out descriptions and tips.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, when opening an issue or a PR, users have to remove the descriptions and tips manually while editing the templates to prevent irrelevant information from being published.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, the descriptions are commented out. Users can still see the tips, but don't have to remove them while editing the template — `.md` markup processor won't display `<!-- -->` comments.

**What might this PR break?**

Nothing.